### PR TITLE
FIX: Unaccounted pixels from the borders of the frame

### DIFF
--- a/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/FlatGroupTaskLine.java
+++ b/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/FlatGroupTaskLine.java
@@ -82,7 +82,7 @@ public class FlatGroupTaskLine extends CompositeTaskLine {
             setCollapseButtonBoundingBox(null);
         }
         // Render name
-        drawCollapsedGroupName(gc, groupXStart, groupYStart, textOffset, rc);
+        drawCollapsedGroupName(gc, groupXStart, groupYStart - 2, textOffset, rc);
         // Render task bottom line
         gc.setStroke(rc.getPanelBorderColor());
         gc.strokeLine(rc.getTaskPanelWidth(), groupYStart + rc.getLineRowHeight(), rc.getImageAreaWidth(), groupYStart + rc.getLineRowHeight());
@@ -168,7 +168,7 @@ public class FlatGroupTaskLine extends CompositeTaskLine {
             setCollapseButtonBoundingBox(null);
         }
         // Render text
-        drawExpandedGroupName(gc, groupXStart, groupYStart, groupBoxWidth, groupBoxHeight, rc);
+        drawExpandedGroupName(gc, groupXStart, groupYStart, groupBoxWidth - 2, groupBoxHeight + 2, rc);
         // If not collapsed, the task projection cannot be rendered in any case
         // Return the box height
         return groupBoxHeight;

--- a/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/HierarchicalGroupTaskLine.java
+++ b/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/HierarchicalGroupTaskLine.java
@@ -105,7 +105,7 @@ public class HierarchicalGroupTaskLine extends CompositeTaskLine {
             setCollapseButtonBoundingBox(null);
         }
         // Render name
-        drawGroupName(gc, groupXStart, groupYStart, textOffset, rc);
+        drawGroupName(gc, groupXStart, groupYStart - 2, textOffset, rc);
         // Render the sub lines
         if(!isCollapsedState()) {
             int i = 1;

--- a/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/TaskItem.java
+++ b/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/TaskItem.java
@@ -206,7 +206,7 @@ public class TaskItem extends LineElement {
                 drawTaskItemProgress(gc, startX, startY, actualEndX - startX, taskHeight, isSelected, rc);
             }
             // Render text
-            drawTaskItemName(gc, startX, startY, endX - startX, taskHeight, isSelected, rc);
+            drawTaskItemName(gc, startX, startY, endX - startX - 2, taskHeight - 2, isSelected, rc);
             // Remember rendering box in pixel coordinates
             updateLastRenderedBounds(new BoundingBox(startX, startY, Math.max(endX, actualEndX) - startX, taskHeight));
         }

--- a/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/TaskLine.java
+++ b/timeline/src/main/java/eu/dariolucia/jfx/timeline/model/TaskLine.java
@@ -128,7 +128,7 @@ public class TaskLine extends LineElement implements ITaskLine {
         // Render the task line box in the task panel
         drawTaskLinePanelBox(gc, taskLineXStart, taskLineYStart, rc.getTaskPanelWidth() - taskLineXStart, taskLineHeight, rc);
         // Render text
-        drawTaskLineName(gc, taskLineXStart, taskLineYStart, rc.getTaskPanelWidth() - taskLineXStart, taskLineHeight, rc);
+        drawTaskLineName(gc, taskLineXStart, taskLineYStart, rc.getTaskPanelWidth() - taskLineXStart - 2, taskLineHeight - 2, rc);
         // Remember boundaries
         updateLastRenderedBounds(new BoundingBox(taskLineXStart, taskLineYStart,
                 rc.getImageAreaWidth() - taskLineXStart, taskLineHeight));


### PR DESCRIPTION
With small values in setTextPadding, the text was incorrectly aligned in height, I assume that this was due to 1-pixel borders being drawn on top of the background.