### PR TITLE
TaskItem disappearing

### DIFF
--- a/timeline/src/main/java/eu/dariolucia/jfx/timeline/Timeline.java
+++ b/timeline/src/main/java/eu/dariolucia/jfx/timeline/Timeline.java
@@ -811,9 +811,9 @@ public class Timeline extends GridPane implements IRenderingContext {
 
     @Override
     public boolean isInViewPort(Instant start, Instant end) {
-        return (start.isAfter(getViewPortStart()) && start.isBefore(getViewPortEnd())) || (
-                end.isAfter(getViewPortStart()) && end.isBefore(getViewPortEnd())) ||
-                (start.isBefore(getViewPortStart()) && end.isAfter(getViewPortEnd()));
+        return (start.compareTo(getViewPortStart()) >= 0 && start.isBefore(getViewPortEnd())) || //If start equal ViewPortStart or start is between viewPortStart and viewPortEnd
+                (end.isAfter(getViewPortStart()) && end.compareTo(getViewPortEnd()) <= 0) || //If end equal ViewPortEnd or end is between viewPortStart and viewPortEnd
+                (start.isBefore(getViewPortStart()) && end.isAfter(getViewPortEnd())); // If start and end are behind viewPortStart and viewPortEnd respectively
     }
 
     public SimpleObjectProperty<Color> panelBorderColorProperty() {


### PR DESCRIPTION
Fixed a bug with TaskItem disappearing if the beginning or end of TaskItem is equal to the beginning or end of viewPort

**Bug demonstration:**
![bandicam 2026-03-02 15-23-56-456 (online-video-cutter com)](https://github.com/user-attachments/assets/f4f463b4-bba8-4ea2-adc0-27333f5262c8)
